### PR TITLE
Fix critical scheduling debug date tracking bug

### DIFF
--- a/src/renderer/utils/flexible-scheduler.ts
+++ b/src/renderer/utils/flexible-scheduler.ts
@@ -1114,6 +1114,26 @@ export function scheduleItemsWithBlocksAndDebug(
           b.date === dateStr && b.blockId === block.blockId,
         )
         if (!alreadyTracked) {
+          const unusedFocus = block.focusMinutesTotal - block.focusMinutesUsed
+          const unusedAdmin = block.adminMinutesTotal - block.adminMinutesUsed
+          const unusedPersonal = block.personalMinutesTotal - block.personalMinutesUsed
+          
+          let unusedReason: string | undefined
+          
+          // Check for completely empty blocks
+          const totalCapacity = block.focusMinutesTotal + block.adminMinutesTotal + block.personalMinutesTotal
+          const totalUsed = block.focusMinutesUsed + block.adminMinutesUsed + block.personalMinutesUsed
+          
+          if (totalUsed === 0 && totalCapacity > 0) {
+            unusedReason = `Empty block: ${totalCapacity} minutes available but unused`
+          } else if (unusedFocus > 30 || unusedAdmin > 30 || unusedPersonal > 30) {
+            const parts: string[] = []
+            if (unusedFocus > 30) parts.push(`${unusedFocus} focus`)
+            if (unusedAdmin > 30) parts.push(`${unusedAdmin} admin`)
+            if (unusedPersonal > 30) parts.push(`${unusedPersonal} personal`)
+            unusedReason = `${parts.join(', ')} minutes unused`
+          }
+          
           debugInfo.blockUtilization.push({
             date: dateStr,
             blockId: block.blockId,
@@ -1123,7 +1143,9 @@ export function scheduleItemsWithBlocksAndDebug(
             focusTotal: block.focusMinutesTotal,
             adminUsed: block.adminMinutesUsed,
             adminTotal: block.adminMinutesTotal,
-            unusedReason: blockState?.timeConstraint ?? null,
+            personalUsed: block.personalMinutesUsed,
+            personalTotal: block.personalMinutesTotal,
+            unusedReason: unusedReason || blockState?.timeConstraint,
           })
         }
       })

--- a/src/renderer/utils/flexible-scheduler.ts
+++ b/src/renderer/utils/flexible-scheduler.ts
@@ -564,12 +564,13 @@ export function scheduleItemsWithBlocksAndDebug(
   const maxDays = 30 // Limit to 30 days
 
   while (workItems.length > 0 && dayIndex < maxDays) {
-    const dateStr = currentDate.toISOString().split('T')[0]
+    let dateStr = currentDate.toISOString().split('T')[0]
     const pattern = patterns.find(p => p.date === dateStr)
 
     if (!pattern || pattern.blocks.length === 0) {
       // No pattern for this day, skip to next day
       currentDate.setDate(currentDate.getDate() + 1)
+      dateStr = currentDate.toISOString().split('T')[0]  // Update dateStr for the new day
       currentTime = new Date(currentDate)
       currentTime.setHours(0, 0, 0, 0)
       // If we've moved to tomorrow, ensure currentTime is not in the past
@@ -1038,6 +1039,7 @@ export function scheduleItemsWithBlocksAndDebug(
 
       currentDate.setDate(currentDate.getDate() + 1)
       dayIndex++
+      dateStr = currentDate.toISOString().split('T')[0]  // Update dateStr for the new day
 
       // Find the next day's pattern and set currentTime to the start of the first block
       const nextDateStr = currentDate.toISOString().split('T')[0]
@@ -1075,6 +1077,7 @@ export function scheduleItemsWithBlocksAndDebug(
       if (currentTime.getTime() >= lastBlockEnd.getTime()) {
         currentDate.setDate(currentDate.getDate() + 1)
         dayIndex++
+        dateStr = currentDate.toISOString().split('T')[0]  // Update dateStr for the new day
 
         // Find the next day's pattern and set currentTime to the start of the first block
         const nextDateStr = currentDate.toISOString().split('T')[0]


### PR DESCRIPTION
## Summary
- Fixed critical bug where scheduling debug info showed blocks as empty when they actually had scheduled items
- Fixed date tracking not being updated when scheduler moves to next day
- Added proper empty block detection and personal capacity tracking

## Root Cause
The `dateStr` variable wasn't being updated when the scheduler moved to the next day, causing block utilization to be tracked with incorrect dates. This made blocks appear empty in the debug info even when items were scheduled.

## Changes
1. Changed `dateStr` from const to let to allow updates
2. Added `dateStr` updates whenever `currentDate` changes (3 locations)
3. Enhanced block utilization tracking with proper empty block detection
4. Added personal capacity tracking that was missing from end-of-loop tracking

## Test plan
- [x] All tests pass
- [x] TypeScript: 0 errors
- [x] Lint: 0 errors (warnings only)
- [ ] Manual testing: Verify debug info now correctly shows scheduled vs empty blocks