### PR TITLE
feat: Add hide completed filter and meeting time display

### DIFF
--- a/context/feedback.json
+++ b/context/feedback.json
@@ -131,5 +131,16 @@
     "actual": "Tasks are not being scheduled, and dependency resolutions are not achieved. ",
     "timestamp": "2025-08-19T23:45:42.119Z",
     "sessionId": "session-1755647142109-djuqis9w9"
+  },
+  {
+    "type": "improvement",
+    "priority": "medium",
+    "components": [
+      "work-logger/WorkLoggerDualView"
+    ],
+    "title": "Circadian rhythm should be user specified",
+    "description": "I go to sleep at like 9 pm, so my circadian second peak is actually at 5 pm ish, where it says I will be at low energy right now! So we need to be able to specify the bedtime or at least read it from the sleep blocks or something. ",
+    "timestamp": "2025-08-20T00:00:16.036Z",
+    "sessionId": "session-1755648016025-m43qdwamm"
   }
 ]

--- a/context/feedback.json
+++ b/context/feedback.json
@@ -108,114 +108,6 @@
     "sessionId": "session-1755635356105-lehziv12g"
   },
   {
-    "type": "bug",
-    "priority": "low",
-    "components": [
-      "timeline/GanttChartSidebar",
-      "schedule/DailyScheduleView"
-    ],
-    "title": "The sidebar doesn't update after logging work",
-    "description": "It requires a window reload in order to update. ",
-    "timestamp": "2025-08-19T22:44:32.477Z",
-    "sessionId": "session-1755643472468-w6o7rucnp"
-  },
-  {
-    "type": "improvement",
-    "priority": "high",
-    "components": [
-      "work-logger/WorkLoggerDualView"
-    ],
-    "title": "Option to hide completed tasks in the timeline view in the dual view work logger",
-    "description": "It gets way too crowded in the work logger view and I need to be able to filter down tasks. We can start by adding a filter for completed tasks. ",
-    "context": "We should probably lay the groundwork for a full featured filtering system. ",
-    "timestamp": "2025-08-19T22:42:25.828Z",
-    "sessionId": "session-1755643345818-jk9nk362t",
-    "resolved": true
-  },
-  {
-    "type": "bug",
-    "priority": "high",
-    "components": [
-      "timeline/GanttChart"
-    ],
-    "title": "Personal Task not displayed",
-    "description": "I made a personal task called 'Task Management app' or something similar, and it is not displayed on the chart (it doesn't have a row)",
-    "timestamp": "2025-08-19T22:39:52.093Z",
-    "sessionId": "session-1755643192084-t2lth9jne"
-  },
-  {
-    "type": "bug",
-    "priority": "medium",
-    "components": [
-      "dev/DevTools"
-    ],
-    "title": "Feedback View Feature Duplicates",
-    "description": "Each feedback item has 3 entries instead of 1, when I try to select one of them, all 3 are selected. Also, we should add the ability to update the feedback text for incomplete tasks. I.e. a feedback item complains about 2 bugs: bug 1 and bug 2, i should be able to change the text so that it only references bug 2 if bug 1 has been fixed. This is easier than completing and making a new one. Also, the prioirty field on the feedback form, even though it is autofilled by default with medium, doesn't recognize that priority has been filled out until you click a priority radio button. ",
-    "timestamp": "2025-08-19T22:39:01.841Z",
-    "sessionId": "session-1755643141834-t0y45odbl",
-    "resolved": true
-  },
-  {
-    "type": "improvement",
-    "priority": "low",
-    "components": [
-      "work-logger/WorkLoggerDualView"
-    ],
-    "title": "\"Now\" Marker on Timeline View",
-    "description": "it would be helpful to have a marker for the current time on the dual view timeline view, similar to how we have it for the Gantt chart",
-    "timestamp": "2025-08-19T22:28:17.517Z",
-    "sessionId": "session-1755642497501-69xszpmlm"
-  },
-  {
-    "type": "improvement",
-    "priority": "medium",
-    "components": [
-      "timeline/GanttChart"
-    ],
-    "title": "Duplicated Row in Gantt Chart from Dual View Feature Work",
-    "description": "When we fixed the bug in the dual view, I think we introduced weird behavior in the Gantt Chart. Now there's a row for meetings, and a row for 'blocked time.' I actually kinda like this though, but the blocked time row should show everything from all rows merged into a single timeline. We still need the row for meetings. But I stored personal time slots like 'sleep' and 'breakfast' and 'exercise' as meetings so that might be why it's just a copy. \n\nThis has been fixed-ish, but I said I wanted a row that showed everything. The implementation for this feedback just deleted the row entirely. ",
-    "timestamp": "2025-08-19T22:19:25.681Z",
-    "sessionId": "session-1755641965656-t4sbx5sfw"
-  },
-  {
-    "type": "bug",
-    "priority": "low",
-    "components": [
-      "work-logger/WorkLoggerDualView"
-    ],
-    "title": "The intervals in the Gantt chart dual view overlap and truncate to an hour",
-    "description": "The intervals in the Gantt chart dual view overlap and truncate to an hour. We also need to display some text for the meetings, and/or provide a tooltip. It's hard to verify it's correct because I can't see what meetings are taking up timeslots. ",
-    "steps": "1. make meetings\n2. click on work logger dual view icon\n3. look at row called \"meetings\"",
-    "expected": "Tooltip, not truncated to 1 hour intervals (show actual duration), and no overlap. ",
-    "timestamp": "2025-08-19T22:16:57.141Z",
-    "sessionId": "session-1755641817124-rfyz5oeo0",
-    "resolved": true
-  },
-  {
-    "type": "bug",
-    "priority": "medium",
-    "components": [
-      "work-logger/WorkLoggerDualView"
-    ],
-    "title": "Time blocks overlap in the chart but not clock",
-    "description": "In the clock, the arcs i see are aligned, but in the gantt chart style timeline view, they overlap",
-    "timestamp": "2025-08-19T20:56:41.954Z",
-    "sessionId": "session-1755637001929-nipnnn0ox",
-    "resolved": true
-  },
-  {
-    "type": "feature",
-    "priority": "high",
-    "title": "Need to see meetings on gantt chart view",
-    "description": "Must have meetings visually to fill out logged time. Should also probably display total meeting time on sidebar, which should probably be listed as a component on the feedback form as well, unless that's what daily schedule view is.\n\nMostly fixed, but we need to display total meeting time on the sidebar, like where I see the \"Today's Planned Capacity\" currently. ",
-    "components": [
-      "work-logger/WorkLoggerDualView",
-      "other"
-    ],
-    "timestamp": "2025-08-19T20:29:16.104Z",
-    "sessionId": "session-1755635356105-lehziv12g"
-  },
-  {
     "type": "feature",
     "priority": "high",
     "components": [
@@ -225,5 +117,19 @@
     "description": "If a task has like a 6 hour duration, but there are no 6 hour work blocks, I think it will never get scheduled. ",
     "timestamp": "2025-08-19T23:42:29.727Z",
     "sessionId": "session-1755646949723-ucei39mub"
+  },
+  {
+    "type": "bug",
+    "priority": "critical",
+    "components": [
+      "utils/flexible-scheduler"
+    ],
+    "title": "Issues with scheduling dependent tasks",
+    "description": "Seeing scheduling issues when I certainly have enough blocks. Seems like the timeline may be not adjusting and leaving things in the past, which need to be done in order for other tasks to get scheduled. 53 empty time block(s) detected in schedule\n6660 minutes of focus time unused while focus tasks remain unscheduled\nUnscheduled Items (4)\nTask\nType\nDuration\nReason\n[ROI Implementation] Verify baby workflow results\nworkflow-step\n60 min\nMissing dependency - one or more dependencies do not exist\n[Safety Certification Task (Monday Deadline)] Get overview of sessions without distance extension\nworkflow-step\n45 min\nMissing dependency - one or more dependencies do not exist\n[Safety Certification Task (Monday Deadline)] Get approvals for CL\nworkflow-step\n30 min\nMissing dependency - one or more dependencies do not exist\nPersonal Task Management App\nfocused\n300 min\nRan out of available days or capacity\nBlock Utilization\nDate\nBlock\nTime\nFocus\nAdmin\nPersonal\nStatus\n2025-08-19\nd803e400-ca9f-454b-98d5-b169d9e3ba27\n5:30:00 AM - 9:00:00 AM\n0/160\n0/50\n-\nEmpty block: 210 minutes available but unused\n2025-08-19\n23defe6a-57d8-4a73-a21a-cad213a2cd76\n9:00:00 AM - 10:30:00 AM\n0/45\n0/45\n-\nEmpty block: 90 minutes available but unused\n2025-08-19\nd0fb5423-6a19-45bb-a289-e9edc7b32934\n11:00:00 AM - 12:00:00 PM\n0/30\n0/30\n-\nEmpty block: 6\n\nThis is the debug output. ",
+    "context": "The data responsbile for this should be in the database still. Issue noticed at 8/19 at 4:45 PM PDT",
+    "expected": "All tasks should be scheduled, even if it's weeks in advance. ",
+    "actual": "Tasks are not being scheduled, and dependency resolutions are not achieved. ",
+    "timestamp": "2025-08-19T23:45:42.119Z",
+    "sessionId": "session-1755647142109-djuqis9w9"
   }
 ]

--- a/context/feedback.json
+++ b/context/feedback.json
@@ -105,7 +105,8 @@
       "other"
     ],
     "timestamp": "2025-08-19T20:29:16.104Z",
-    "sessionId": "session-1755635356105-lehziv12g"
+    "sessionId": "session-1755635356105-lehziv12g",
+    "resolved": true
   },
   {
     "type": "feature",

--- a/context/feedback.json
+++ b/context/feedback.json
@@ -143,5 +143,16 @@
     "description": "I go to sleep at like 9 pm, so my circadian second peak is actually at 5 pm ish, where it says I will be at low energy right now! So we need to be able to specify the bedtime or at least read it from the sleep blocks or something. ",
     "timestamp": "2025-08-20T00:00:16.036Z",
     "sessionId": "session-1755648016025-m43qdwamm"
+  },
+  {
+    "type": "bug",
+    "priority": "low",
+    "components": [
+      "other"
+    ],
+    "title": "Y axis of eisenhower matrix interferes with rendered text",
+    "description": "It's too far to the right, overlapping the first two blocks (column). Is this component even in the feedback affected components list?",
+    "timestamp": "2025-08-20T00:12:00.160Z",
+    "sessionId": "session-1755648720152-smzzn95hp"
   }
 ]

--- a/context/feedback.json
+++ b/context/feedback.json
@@ -21,7 +21,8 @@
     "description": "It gets way too crowded in the work logger view and I need to be able to filter down tasks. We can start by adding a filter for completed tasks. ",
     "context": "We should probably lay the groundwork for a full featured filtering system. ",
     "timestamp": "2025-08-19T22:42:25.828Z",
-    "sessionId": "session-1755643345818-jk9nk362t"
+    "sessionId": "session-1755643345818-jk9nk362t",
+    "resolved": true
   },
   {
     "type": "bug",
@@ -105,5 +106,124 @@
     ],
     "timestamp": "2025-08-19T20:29:16.104Z",
     "sessionId": "session-1755635356105-lehziv12g"
+  },
+  {
+    "type": "bug",
+    "priority": "low",
+    "components": [
+      "timeline/GanttChartSidebar",
+      "schedule/DailyScheduleView"
+    ],
+    "title": "The sidebar doesn't update after logging work",
+    "description": "It requires a window reload in order to update. ",
+    "timestamp": "2025-08-19T22:44:32.477Z",
+    "sessionId": "session-1755643472468-w6o7rucnp"
+  },
+  {
+    "type": "improvement",
+    "priority": "high",
+    "components": [
+      "work-logger/WorkLoggerDualView"
+    ],
+    "title": "Option to hide completed tasks in the timeline view in the dual view work logger",
+    "description": "It gets way too crowded in the work logger view and I need to be able to filter down tasks. We can start by adding a filter for completed tasks. ",
+    "context": "We should probably lay the groundwork for a full featured filtering system. ",
+    "timestamp": "2025-08-19T22:42:25.828Z",
+    "sessionId": "session-1755643345818-jk9nk362t",
+    "resolved": true
+  },
+  {
+    "type": "bug",
+    "priority": "high",
+    "components": [
+      "timeline/GanttChart"
+    ],
+    "title": "Personal Task not displayed",
+    "description": "I made a personal task called 'Task Management app' or something similar, and it is not displayed on the chart (it doesn't have a row)",
+    "timestamp": "2025-08-19T22:39:52.093Z",
+    "sessionId": "session-1755643192084-t2lth9jne"
+  },
+  {
+    "type": "bug",
+    "priority": "medium",
+    "components": [
+      "dev/DevTools"
+    ],
+    "title": "Feedback View Feature Duplicates",
+    "description": "Each feedback item has 3 entries instead of 1, when I try to select one of them, all 3 are selected. Also, we should add the ability to update the feedback text for incomplete tasks. I.e. a feedback item complains about 2 bugs: bug 1 and bug 2, i should be able to change the text so that it only references bug 2 if bug 1 has been fixed. This is easier than completing and making a new one. Also, the prioirty field on the feedback form, even though it is autofilled by default with medium, doesn't recognize that priority has been filled out until you click a priority radio button. ",
+    "timestamp": "2025-08-19T22:39:01.841Z",
+    "sessionId": "session-1755643141834-t0y45odbl",
+    "resolved": true
+  },
+  {
+    "type": "improvement",
+    "priority": "low",
+    "components": [
+      "work-logger/WorkLoggerDualView"
+    ],
+    "title": "\"Now\" Marker on Timeline View",
+    "description": "it would be helpful to have a marker for the current time on the dual view timeline view, similar to how we have it for the Gantt chart",
+    "timestamp": "2025-08-19T22:28:17.517Z",
+    "sessionId": "session-1755642497501-69xszpmlm"
+  },
+  {
+    "type": "improvement",
+    "priority": "medium",
+    "components": [
+      "timeline/GanttChart"
+    ],
+    "title": "Duplicated Row in Gantt Chart from Dual View Feature Work",
+    "description": "When we fixed the bug in the dual view, I think we introduced weird behavior in the Gantt Chart. Now there's a row for meetings, and a row for 'blocked time.' I actually kinda like this though, but the blocked time row should show everything from all rows merged into a single timeline. We still need the row for meetings. But I stored personal time slots like 'sleep' and 'breakfast' and 'exercise' as meetings so that might be why it's just a copy. \n\nThis has been fixed-ish, but I said I wanted a row that showed everything. The implementation for this feedback just deleted the row entirely. ",
+    "timestamp": "2025-08-19T22:19:25.681Z",
+    "sessionId": "session-1755641965656-t4sbx5sfw"
+  },
+  {
+    "type": "bug",
+    "priority": "low",
+    "components": [
+      "work-logger/WorkLoggerDualView"
+    ],
+    "title": "The intervals in the Gantt chart dual view overlap and truncate to an hour",
+    "description": "The intervals in the Gantt chart dual view overlap and truncate to an hour. We also need to display some text for the meetings, and/or provide a tooltip. It's hard to verify it's correct because I can't see what meetings are taking up timeslots. ",
+    "steps": "1. make meetings\n2. click on work logger dual view icon\n3. look at row called \"meetings\"",
+    "expected": "Tooltip, not truncated to 1 hour intervals (show actual duration), and no overlap. ",
+    "timestamp": "2025-08-19T22:16:57.141Z",
+    "sessionId": "session-1755641817124-rfyz5oeo0",
+    "resolved": true
+  },
+  {
+    "type": "bug",
+    "priority": "medium",
+    "components": [
+      "work-logger/WorkLoggerDualView"
+    ],
+    "title": "Time blocks overlap in the chart but not clock",
+    "description": "In the clock, the arcs i see are aligned, but in the gantt chart style timeline view, they overlap",
+    "timestamp": "2025-08-19T20:56:41.954Z",
+    "sessionId": "session-1755637001929-nipnnn0ox",
+    "resolved": true
+  },
+  {
+    "type": "feature",
+    "priority": "high",
+    "title": "Need to see meetings on gantt chart view",
+    "description": "Must have meetings visually to fill out logged time. Should also probably display total meeting time on sidebar, which should probably be listed as a component on the feedback form as well, unless that's what daily schedule view is.\n\nMostly fixed, but we need to display total meeting time on the sidebar, like where I see the \"Today's Planned Capacity\" currently. ",
+    "components": [
+      "work-logger/WorkLoggerDualView",
+      "other"
+    ],
+    "timestamp": "2025-08-19T20:29:16.104Z",
+    "sessionId": "session-1755635356105-lehziv12g"
+  },
+  {
+    "type": "feature",
+    "priority": "high",
+    "components": [
+      "utils/flexible-scheduler"
+    ],
+    "title": "Allow splitting of tasks to schedule tasks with long durations",
+    "description": "If a task has like a 6 hour duration, but there are no 6 hour work blocks, I think it will never get scheduled. ",
+    "timestamp": "2025-08-19T23:42:29.727Z",
+    "sessionId": "session-1755646949723-ucei39mub"
   }
 ]

--- a/context/feedback_backup.json
+++ b/context/feedback_backup.json
@@ -1,0 +1,470 @@
+[
+  {
+    "type": "bug",
+    "priority": "low",
+    "components": [
+      "timeline/GanttChartSidebar",
+      "schedule/DailyScheduleView"
+    ],
+    "title": "The sidebar doesn't update after logging work",
+    "description": "It requires a window reload in order to update. ",
+    "timestamp": "2025-08-19T22:44:32.477Z",
+    "sessionId": "session-1755643472468-w6o7rucnp"
+  },
+  {
+    "type": "improvement",
+    "priority": "high",
+    "components": [
+      "work-logger/WorkLoggerDualView"
+    ],
+    "title": "Option to hide completed tasks in the timeline view in the dual view work logger",
+    "description": "It gets way too crowded in the work logger view and I need to be able to filter down tasks. We can start by adding a filter for completed tasks. ",
+    "context": "We should probably lay the groundwork for a full featured filtering system. ",
+    "timestamp": "2025-08-19T22:42:25.828Z",
+    "sessionId": "session-1755643345818-jk9nk362t",
+    "resolved": true
+  },
+  {
+    "type": "bug",
+    "priority": "high",
+    "components": [
+      "timeline/GanttChart"
+    ],
+    "title": "Personal Task not displayed",
+    "description": "I made a personal task called 'Task Management app' or something similar, and it is not displayed on the chart (it doesn't have a row)",
+    "timestamp": "2025-08-19T22:39:52.093Z",
+    "sessionId": "session-1755643192084-t2lth9jne"
+  },
+  {
+    "type": "bug",
+    "priority": "medium",
+    "components": [
+      "dev/DevTools"
+    ],
+    "title": "Feedback View Feature Duplicates",
+    "description": "Each feedback item has 3 entries instead of 1, when I try to select one of them, all 3 are selected. Also, we should add the ability to update the feedback text for incomplete tasks. I.e. a feedback item complains about 2 bugs: bug 1 and bug 2, i should be able to change the text so that it only references bug 2 if bug 1 has been fixed. This is easier than completing and making a new one. Also, the prioirty field on the feedback form, even though it is autofilled by default with medium, doesn't recognize that priority has been filled out until you click a priority radio button. ",
+    "timestamp": "2025-08-19T22:39:01.841Z",
+    "sessionId": "session-1755643141834-t0y45odbl",
+    "resolved": true
+  },
+  {
+    "type": "improvement",
+    "priority": "low",
+    "components": [
+      "work-logger/WorkLoggerDualView"
+    ],
+    "title": "\"Now\" Marker on Timeline View",
+    "description": "it would be helpful to have a marker for the current time on the dual view timeline view, similar to how we have it for the Gantt chart",
+    "timestamp": "2025-08-19T22:28:17.517Z",
+    "sessionId": "session-1755642497501-69xszpmlm"
+  },
+  {
+    "type": "improvement",
+    "priority": "medium",
+    "components": [
+      "timeline/GanttChart"
+    ],
+    "title": "Duplicated Row in Gantt Chart from Dual View Feature Work",
+    "description": "When we fixed the bug in the dual view, I think we introduced weird behavior in the Gantt Chart. Now there's a row for meetings, and a row for 'blocked time.' I actually kinda like this though, but the blocked time row should show everything from all rows merged into a single timeline. We still need the row for meetings. But I stored personal time slots like 'sleep' and 'breakfast' and 'exercise' as meetings so that might be why it's just a copy. \n\nThis has been fixed-ish, but I said I wanted a row that showed everything. The implementation for this feedback just deleted the row entirely. ",
+    "timestamp": "2025-08-19T22:19:25.681Z",
+    "sessionId": "session-1755641965656-t4sbx5sfw"
+  },
+  {
+    "type": "bug",
+    "priority": "low",
+    "components": [
+      "work-logger/WorkLoggerDualView"
+    ],
+    "title": "The intervals in the Gantt chart dual view overlap and truncate to an hour",
+    "description": "The intervals in the Gantt chart dual view overlap and truncate to an hour. We also need to display some text for the meetings, and/or provide a tooltip. It's hard to verify it's correct because I can't see what meetings are taking up timeslots. ",
+    "steps": "1. make meetings\n2. click on work logger dual view icon\n3. look at row called \"meetings\"",
+    "expected": "Tooltip, not truncated to 1 hour intervals (show actual duration), and no overlap. ",
+    "timestamp": "2025-08-19T22:16:57.141Z",
+    "sessionId": "session-1755641817124-rfyz5oeo0",
+    "resolved": true
+  },
+  {
+    "type": "bug",
+    "priority": "medium",
+    "components": [
+      "work-logger/WorkLoggerDualView"
+    ],
+    "title": "Time blocks overlap in the chart but not clock",
+    "description": "In the clock, the arcs i see are aligned, but in the gantt chart style timeline view, they overlap",
+    "timestamp": "2025-08-19T20:56:41.954Z",
+    "sessionId": "session-1755637001929-nipnnn0ox",
+    "resolved": true
+  },
+  {
+    "type": "feature",
+    "priority": "high",
+    "title": "Need to see meetings on gantt chart view",
+    "description": "Must have meetings visually to fill out logged time. Should also probably display total meeting time on sidebar, which should probably be listed as a component on the feedback form as well, unless that's what daily schedule view is.\n\nMostly fixed, but we need to display total meeting time on the sidebar, like where I see the \"Today's Planned Capacity\" currently. ",
+    "components": [
+      "work-logger/WorkLoggerDualView",
+      "other"
+    ],
+    "timestamp": "2025-08-19T20:29:16.104Z",
+    "sessionId": "session-1755635356105-lehziv12g"
+  },
+  {
+    "type": "bug",
+    "priority": "low",
+    "components": [
+      "timeline/GanttChartSidebar",
+      "schedule/DailyScheduleView"
+    ],
+    "title": "The sidebar doesn't update after logging work",
+    "description": "It requires a window reload in order to update. ",
+    "timestamp": "2025-08-19T22:44:32.477Z",
+    "sessionId": "session-1755643472468-w6o7rucnp"
+  },
+  {
+    "type": "improvement",
+    "priority": "high",
+    "components": [
+      "work-logger/WorkLoggerDualView"
+    ],
+    "title": "Option to hide completed tasks in the timeline view in the dual view work logger",
+    "description": "It gets way too crowded in the work logger view and I need to be able to filter down tasks. We can start by adding a filter for completed tasks. ",
+    "context": "We should probably lay the groundwork for a full featured filtering system. ",
+    "timestamp": "2025-08-19T22:42:25.828Z",
+    "sessionId": "session-1755643345818-jk9nk362t",
+    "resolved": true
+  },
+  {
+    "type": "bug",
+    "priority": "high",
+    "components": [
+      "timeline/GanttChart"
+    ],
+    "title": "Personal Task not displayed",
+    "description": "I made a personal task called 'Task Management app' or something similar, and it is not displayed on the chart (it doesn't have a row)",
+    "timestamp": "2025-08-19T22:39:52.093Z",
+    "sessionId": "session-1755643192084-t2lth9jne"
+  },
+  {
+    "type": "bug",
+    "priority": "medium",
+    "components": [
+      "dev/DevTools"
+    ],
+    "title": "Feedback View Feature Duplicates",
+    "description": "Each feedback item has 3 entries instead of 1, when I try to select one of them, all 3 are selected. Also, we should add the ability to update the feedback text for incomplete tasks. I.e. a feedback item complains about 2 bugs: bug 1 and bug 2, i should be able to change the text so that it only references bug 2 if bug 1 has been fixed. This is easier than completing and making a new one. Also, the prioirty field on the feedback form, even though it is autofilled by default with medium, doesn't recognize that priority has been filled out until you click a priority radio button. ",
+    "timestamp": "2025-08-19T22:39:01.841Z",
+    "sessionId": "session-1755643141834-t0y45odbl",
+    "resolved": true
+  },
+  {
+    "type": "improvement",
+    "priority": "low",
+    "components": [
+      "work-logger/WorkLoggerDualView"
+    ],
+    "title": "\"Now\" Marker on Timeline View",
+    "description": "it would be helpful to have a marker for the current time on the dual view timeline view, similar to how we have it for the Gantt chart",
+    "timestamp": "2025-08-19T22:28:17.517Z",
+    "sessionId": "session-1755642497501-69xszpmlm"
+  },
+  {
+    "type": "improvement",
+    "priority": "medium",
+    "components": [
+      "timeline/GanttChart"
+    ],
+    "title": "Duplicated Row in Gantt Chart from Dual View Feature Work",
+    "description": "When we fixed the bug in the dual view, I think we introduced weird behavior in the Gantt Chart. Now there's a row for meetings, and a row for 'blocked time.' I actually kinda like this though, but the blocked time row should show everything from all rows merged into a single timeline. We still need the row for meetings. But I stored personal time slots like 'sleep' and 'breakfast' and 'exercise' as meetings so that might be why it's just a copy. \n\nThis has been fixed-ish, but I said I wanted a row that showed everything. The implementation for this feedback just deleted the row entirely. ",
+    "timestamp": "2025-08-19T22:19:25.681Z",
+    "sessionId": "session-1755641965656-t4sbx5sfw"
+  },
+  {
+    "type": "bug",
+    "priority": "low",
+    "components": [
+      "work-logger/WorkLoggerDualView"
+    ],
+    "title": "The intervals in the Gantt chart dual view overlap and truncate to an hour",
+    "description": "The intervals in the Gantt chart dual view overlap and truncate to an hour. We also need to display some text for the meetings, and/or provide a tooltip. It's hard to verify it's correct because I can't see what meetings are taking up timeslots. ",
+    "steps": "1. make meetings\n2. click on work logger dual view icon\n3. look at row called \"meetings\"",
+    "expected": "Tooltip, not truncated to 1 hour intervals (show actual duration), and no overlap. ",
+    "timestamp": "2025-08-19T22:16:57.141Z",
+    "sessionId": "session-1755641817124-rfyz5oeo0",
+    "resolved": true
+  },
+  {
+    "type": "bug",
+    "priority": "medium",
+    "components": [
+      "work-logger/WorkLoggerDualView"
+    ],
+    "title": "Time blocks overlap in the chart but not clock",
+    "description": "In the clock, the arcs i see are aligned, but in the gantt chart style timeline view, they overlap",
+    "timestamp": "2025-08-19T20:56:41.954Z",
+    "sessionId": "session-1755637001929-nipnnn0ox",
+    "resolved": true
+  },
+  {
+    "type": "feature",
+    "priority": "high",
+    "title": "Need to see meetings on gantt chart view",
+    "description": "Must have meetings visually to fill out logged time. Should also probably display total meeting time on sidebar, which should probably be listed as a component on the feedback form as well, unless that's what daily schedule view is.\n\nMostly fixed, but we need to display total meeting time on the sidebar, like where I see the \"Today's Planned Capacity\" currently. ",
+    "components": [
+      "work-logger/WorkLoggerDualView",
+      "other"
+    ],
+    "timestamp": "2025-08-19T20:29:16.104Z",
+    "sessionId": "session-1755635356105-lehziv12g"
+  },
+  {
+    "type": "feature",
+    "priority": "high",
+    "components": [
+      "utils/flexible-scheduler"
+    ],
+    "title": "Allow splitting of tasks to schedule tasks with long durations",
+    "description": "If a task has like a 6 hour duration, but there are no 6 hour work blocks, I think it will never get scheduled. ",
+    "timestamp": "2025-08-19T23:42:29.727Z",
+    "sessionId": "session-1755646949723-ucei39mub"
+  },
+  {
+    "type": "bug",
+    "priority": "low",
+    "components": [
+      "timeline/GanttChartSidebar",
+      "schedule/DailyScheduleView"
+    ],
+    "title": "The sidebar doesn't update after logging work",
+    "description": "It requires a window reload in order to update. ",
+    "timestamp": "2025-08-19T22:44:32.477Z",
+    "sessionId": "session-1755643472468-w6o7rucnp"
+  },
+  {
+    "type": "improvement",
+    "priority": "high",
+    "components": [
+      "work-logger/WorkLoggerDualView"
+    ],
+    "title": "Option to hide completed tasks in the timeline view in the dual view work logger",
+    "description": "It gets way too crowded in the work logger view and I need to be able to filter down tasks. We can start by adding a filter for completed tasks. ",
+    "context": "We should probably lay the groundwork for a full featured filtering system. ",
+    "timestamp": "2025-08-19T22:42:25.828Z",
+    "sessionId": "session-1755643345818-jk9nk362t",
+    "resolved": true
+  },
+  {
+    "type": "bug",
+    "priority": "high",
+    "components": [
+      "timeline/GanttChart"
+    ],
+    "title": "Personal Task not displayed",
+    "description": "I made a personal task called 'Task Management app' or something similar, and it is not displayed on the chart (it doesn't have a row)",
+    "timestamp": "2025-08-19T22:39:52.093Z",
+    "sessionId": "session-1755643192084-t2lth9jne"
+  },
+  {
+    "type": "bug",
+    "priority": "medium",
+    "components": [
+      "dev/DevTools"
+    ],
+    "title": "Feedback View Feature Duplicates",
+    "description": "Each feedback item has 3 entries instead of 1, when I try to select one of them, all 3 are selected. Also, we should add the ability to update the feedback text for incomplete tasks. I.e. a feedback item complains about 2 bugs: bug 1 and bug 2, i should be able to change the text so that it only references bug 2 if bug 1 has been fixed. This is easier than completing and making a new one. Also, the prioirty field on the feedback form, even though it is autofilled by default with medium, doesn't recognize that priority has been filled out until you click a priority radio button. ",
+    "timestamp": "2025-08-19T22:39:01.841Z",
+    "sessionId": "session-1755643141834-t0y45odbl",
+    "resolved": true
+  },
+  {
+    "type": "improvement",
+    "priority": "low",
+    "components": [
+      "work-logger/WorkLoggerDualView"
+    ],
+    "title": "\"Now\" Marker on Timeline View",
+    "description": "it would be helpful to have a marker for the current time on the dual view timeline view, similar to how we have it for the Gantt chart",
+    "timestamp": "2025-08-19T22:28:17.517Z",
+    "sessionId": "session-1755642497501-69xszpmlm"
+  },
+  {
+    "type": "improvement",
+    "priority": "medium",
+    "components": [
+      "timeline/GanttChart"
+    ],
+    "title": "Duplicated Row in Gantt Chart from Dual View Feature Work",
+    "description": "When we fixed the bug in the dual view, I think we introduced weird behavior in the Gantt Chart. Now there's a row for meetings, and a row for 'blocked time.' I actually kinda like this though, but the blocked time row should show everything from all rows merged into a single timeline. We still need the row for meetings. But I stored personal time slots like 'sleep' and 'breakfast' and 'exercise' as meetings so that might be why it's just a copy. \n\nThis has been fixed-ish, but I said I wanted a row that showed everything. The implementation for this feedback just deleted the row entirely. ",
+    "timestamp": "2025-08-19T22:19:25.681Z",
+    "sessionId": "session-1755641965656-t4sbx5sfw"
+  },
+  {
+    "type": "bug",
+    "priority": "low",
+    "components": [
+      "work-logger/WorkLoggerDualView"
+    ],
+    "title": "The intervals in the Gantt chart dual view overlap and truncate to an hour",
+    "description": "The intervals in the Gantt chart dual view overlap and truncate to an hour. We also need to display some text for the meetings, and/or provide a tooltip. It's hard to verify it's correct because I can't see what meetings are taking up timeslots. ",
+    "steps": "1. make meetings\n2. click on work logger dual view icon\n3. look at row called \"meetings\"",
+    "expected": "Tooltip, not truncated to 1 hour intervals (show actual duration), and no overlap. ",
+    "timestamp": "2025-08-19T22:16:57.141Z",
+    "sessionId": "session-1755641817124-rfyz5oeo0",
+    "resolved": true
+  },
+  {
+    "type": "bug",
+    "priority": "medium",
+    "components": [
+      "work-logger/WorkLoggerDualView"
+    ],
+    "title": "Time blocks overlap in the chart but not clock",
+    "description": "In the clock, the arcs i see are aligned, but in the gantt chart style timeline view, they overlap",
+    "timestamp": "2025-08-19T20:56:41.954Z",
+    "sessionId": "session-1755637001929-nipnnn0ox",
+    "resolved": true
+  },
+  {
+    "type": "feature",
+    "priority": "high",
+    "title": "Need to see meetings on gantt chart view",
+    "description": "Must have meetings visually to fill out logged time. Should also probably display total meeting time on sidebar, which should probably be listed as a component on the feedback form as well, unless that's what daily schedule view is.\n\nMostly fixed, but we need to display total meeting time on the sidebar, like where I see the \"Today's Planned Capacity\" currently. ",
+    "components": [
+      "work-logger/WorkLoggerDualView",
+      "other"
+    ],
+    "timestamp": "2025-08-19T20:29:16.104Z",
+    "sessionId": "session-1755635356105-lehziv12g"
+  },
+  {
+    "type": "bug",
+    "priority": "low",
+    "components": [
+      "timeline/GanttChartSidebar",
+      "schedule/DailyScheduleView"
+    ],
+    "title": "The sidebar doesn't update after logging work",
+    "description": "It requires a window reload in order to update. ",
+    "timestamp": "2025-08-19T22:44:32.477Z",
+    "sessionId": "session-1755643472468-w6o7rucnp"
+  },
+  {
+    "type": "improvement",
+    "priority": "high",
+    "components": [
+      "work-logger/WorkLoggerDualView"
+    ],
+    "title": "Option to hide completed tasks in the timeline view in the dual view work logger",
+    "description": "It gets way too crowded in the work logger view and I need to be able to filter down tasks. We can start by adding a filter for completed tasks. ",
+    "context": "We should probably lay the groundwork for a full featured filtering system. ",
+    "timestamp": "2025-08-19T22:42:25.828Z",
+    "sessionId": "session-1755643345818-jk9nk362t",
+    "resolved": true
+  },
+  {
+    "type": "bug",
+    "priority": "high",
+    "components": [
+      "timeline/GanttChart"
+    ],
+    "title": "Personal Task not displayed",
+    "description": "I made a personal task called 'Task Management app' or something similar, and it is not displayed on the chart (it doesn't have a row)",
+    "timestamp": "2025-08-19T22:39:52.093Z",
+    "sessionId": "session-1755643192084-t2lth9jne"
+  },
+  {
+    "type": "bug",
+    "priority": "medium",
+    "components": [
+      "dev/DevTools"
+    ],
+    "title": "Feedback View Feature Duplicates",
+    "description": "Each feedback item has 3 entries instead of 1, when I try to select one of them, all 3 are selected. Also, we should add the ability to update the feedback text for incomplete tasks. I.e. a feedback item complains about 2 bugs: bug 1 and bug 2, i should be able to change the text so that it only references bug 2 if bug 1 has been fixed. This is easier than completing and making a new one. Also, the prioirty field on the feedback form, even though it is autofilled by default with medium, doesn't recognize that priority has been filled out until you click a priority radio button. ",
+    "timestamp": "2025-08-19T22:39:01.841Z",
+    "sessionId": "session-1755643141834-t0y45odbl",
+    "resolved": true
+  },
+  {
+    "type": "improvement",
+    "priority": "low",
+    "components": [
+      "work-logger/WorkLoggerDualView"
+    ],
+    "title": "\"Now\" Marker on Timeline View",
+    "description": "it would be helpful to have a marker for the current time on the dual view timeline view, similar to how we have it for the Gantt chart",
+    "timestamp": "2025-08-19T22:28:17.517Z",
+    "sessionId": "session-1755642497501-69xszpmlm"
+  },
+  {
+    "type": "improvement",
+    "priority": "medium",
+    "components": [
+      "timeline/GanttChart"
+    ],
+    "title": "Duplicated Row in Gantt Chart from Dual View Feature Work",
+    "description": "When we fixed the bug in the dual view, I think we introduced weird behavior in the Gantt Chart. Now there's a row for meetings, and a row for 'blocked time.' I actually kinda like this though, but the blocked time row should show everything from all rows merged into a single timeline. We still need the row for meetings. But I stored personal time slots like 'sleep' and 'breakfast' and 'exercise' as meetings so that might be why it's just a copy. \n\nThis has been fixed-ish, but I said I wanted a row that showed everything. The implementation for this feedback just deleted the row entirely. ",
+    "timestamp": "2025-08-19T22:19:25.681Z",
+    "sessionId": "session-1755641965656-t4sbx5sfw"
+  },
+  {
+    "type": "bug",
+    "priority": "low",
+    "components": [
+      "work-logger/WorkLoggerDualView"
+    ],
+    "title": "The intervals in the Gantt chart dual view overlap and truncate to an hour",
+    "description": "The intervals in the Gantt chart dual view overlap and truncate to an hour. We also need to display some text for the meetings, and/or provide a tooltip. It's hard to verify it's correct because I can't see what meetings are taking up timeslots. ",
+    "steps": "1. make meetings\n2. click on work logger dual view icon\n3. look at row called \"meetings\"",
+    "expected": "Tooltip, not truncated to 1 hour intervals (show actual duration), and no overlap. ",
+    "timestamp": "2025-08-19T22:16:57.141Z",
+    "sessionId": "session-1755641817124-rfyz5oeo0",
+    "resolved": true
+  },
+  {
+    "type": "bug",
+    "priority": "medium",
+    "components": [
+      "work-logger/WorkLoggerDualView"
+    ],
+    "title": "Time blocks overlap in the chart but not clock",
+    "description": "In the clock, the arcs i see are aligned, but in the gantt chart style timeline view, they overlap",
+    "timestamp": "2025-08-19T20:56:41.954Z",
+    "sessionId": "session-1755637001929-nipnnn0ox",
+    "resolved": true
+  },
+  {
+    "type": "feature",
+    "priority": "high",
+    "title": "Need to see meetings on gantt chart view",
+    "description": "Must have meetings visually to fill out logged time. Should also probably display total meeting time on sidebar, which should probably be listed as a component on the feedback form as well, unless that's what daily schedule view is.\n\nMostly fixed, but we need to display total meeting time on the sidebar, like where I see the \"Today's Planned Capacity\" currently. ",
+    "components": [
+      "work-logger/WorkLoggerDualView",
+      "other"
+    ],
+    "timestamp": "2025-08-19T20:29:16.104Z",
+    "sessionId": "session-1755635356105-lehziv12g"
+  },
+  {
+    "type": "feature",
+    "priority": "high",
+    "components": [
+      "utils/flexible-scheduler"
+    ],
+    "title": "Allow splitting of tasks to schedule tasks with long durations",
+    "description": "If a task has like a 6 hour duration, but there are no 6 hour work blocks, I think it will never get scheduled. ",
+    "timestamp": "2025-08-19T23:42:29.727Z",
+    "sessionId": "session-1755646949723-ucei39mub"
+  },
+  {
+    "type": "bug",
+    "priority": "critical",
+    "components": [
+      "utils/flexible-scheduler"
+    ],
+    "title": "Issues with scheduling dependent tasks",
+    "description": "Seeing scheduling issues when I certainly have enough blocks. Seems like the timeline may be not adjusting and leaving things in the past, which need to be done in order for other tasks to get scheduled. 53 empty time block(s) detected in schedule\n6660 minutes of focus time unused while focus tasks remain unscheduled\nUnscheduled Items (4)\nTask\nType\nDuration\nReason\n[ROI Implementation] Verify baby workflow results\nworkflow-step\n60 min\nMissing dependency - one or more dependencies do not exist\n[Safety Certification Task (Monday Deadline)] Get overview of sessions without distance extension\nworkflow-step\n45 min\nMissing dependency - one or more dependencies do not exist\n[Safety Certification Task (Monday Deadline)] Get approvals for CL\nworkflow-step\n30 min\nMissing dependency - one or more dependencies do not exist\nPersonal Task Management App\nfocused\n300 min\nRan out of available days or capacity\nBlock Utilization\nDate\nBlock\nTime\nFocus\nAdmin\nPersonal\nStatus\n2025-08-19\nd803e400-ca9f-454b-98d5-b169d9e3ba27\n5:30:00 AM - 9:00:00 AM\n0/160\n0/50\n-\nEmpty block: 210 minutes available but unused\n2025-08-19\n23defe6a-57d8-4a73-a21a-cad213a2cd76\n9:00:00 AM - 10:30:00 AM\n0/45\n0/45\n-\nEmpty block: 90 minutes available but unused\n2025-08-19\nd0fb5423-6a19-45bb-a289-e9edc7b32934\n11:00:00 AM - 12:00:00 PM\n0/30\n0/30\n-\nEmpty block: 6\n\nThis is the debug output. ",
+    "context": "The data responsbile for this should be in the database still. Issue noticed at 8/19 at 4:45 PM PDT",
+    "expected": "All tasks should be scheduled, even if it's weeks in advance. ",
+    "actual": "Tasks are not being scheduled, and dependency resolutions are not achieved. ",
+    "timestamp": "2025-08-19T23:45:42.119Z",
+    "sessionId": "session-1755647142109-djuqis9w9"
+  }
+]

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -434,9 +434,9 @@ ipcMain.handle('feedback:save', async (_event, feedback) => {
       feedback.forEach(item => {
         if (item && typeof item === 'object' && 'type' in item) {
           // Check for duplicates before adding
-          const isDuplicate = allFeedback.some(existing => 
-            existing.timestamp === item.timestamp && 
-            existing.sessionId === item.sessionId
+          const isDuplicate = allFeedback.some(existing =>
+            existing.timestamp === item.timestamp &&
+            existing.sessionId === item.sessionId,
           )
           if (!isDuplicate) {
             allFeedback.push(item)
@@ -445,9 +445,9 @@ ipcMain.handle('feedback:save', async (_event, feedback) => {
       })
     } else if (feedback && typeof feedback === 'object' && 'type' in feedback) {
       // Check for duplicates before adding
-      const isDuplicate = allFeedback.some(existing => 
-        existing.timestamp === feedback.timestamp && 
-        existing.sessionId === feedback.sessionId
+      const isDuplicate = allFeedback.some(existing =>
+        existing.timestamp === feedback.timestamp &&
+        existing.sessionId === feedback.sessionId,
       )
       if (!isDuplicate) {
         allFeedback.push(feedback)
@@ -525,10 +525,10 @@ ipcMain.handle('feedback:update', async (_event, updatedFeedback) => {
 
     // Deduplicate feedback items based on timestamp and sessionId
     const uniqueFeedback = flatFeedback.filter((item, index, self) =>
-      index === self.findIndex(f => 
-        f.timestamp === item.timestamp && 
-        f.sessionId === item.sessionId
-      )
+      index === self.findIndex(f =>
+        f.timestamp === item.timestamp &&
+        f.sessionId === item.sessionId,
+      ),
     )
 
     // Save updated feedback (ensure it's a flat, deduplicated array)

--- a/src/renderer/components/dev/FeedbackForm.tsx
+++ b/src/renderer/components/dev/FeedbackForm.tsx
@@ -34,6 +34,7 @@ const COMPONENT_OPTIONS = [
   { label: 'Task Edit Form', value: 'tasks/TaskEdit' },
   { label: 'Gantt Chart', value: 'timeline/GanttChart' },
   { label: 'Gantt Chart Sidebar', value: 'timeline/GanttChartSidebar' },
+  { label: 'Work Status Widget', value: 'status/WorkStatusWidget' },
   { label: 'Work Logger (Dual View)', value: 'work-logger/WorkLoggerDualView' },
   { label: 'Work Logger Calendar', value: 'work-logger/WorkLoggerCalendar' },
   { label: 'Weekly Calendar', value: 'calendar/WeeklyCalendar' },

--- a/src/renderer/components/status/WorkStatusWidget.tsx
+++ b/src/renderer/components/status/WorkStatusWidget.tsx
@@ -58,10 +58,9 @@ export function WorkStatusWidget({ onEditSchedule }: WorkStatusWidgetProps) {
   const loadWorkData = async () => {
     try {
       const db = getDatabase()
-      const [patternData, accumulatedData, workSessions] = await Promise.all([
+      const [patternData, accumulatedData] = await Promise.all([
         db.getWorkPattern(currentDate),
         db.getTodayAccumulated(currentDate),
-        db.getWorkSessions(currentDate),
       ])
 
       setPattern(patternData)
@@ -69,7 +68,7 @@ export function WorkStatusWidget({ onEditSchedule }: WorkStatusWidgetProps) {
         focused: accumulatedData.focused || 0,
         admin: accumulatedData.admin || 0,
       })
-      
+
       // Calculate meeting time from work sessions
       let totalMeetingMinutes = 0
       if (patternData && patternData.meetings) {
@@ -259,7 +258,7 @@ export function WorkStatusWidget({ onEditSchedule }: WorkStatusWidgetProps) {
               <Space style={{ width: '100%', justifyContent: 'space-between' }}>
                 <Text style={{ fontWeight: 600 }}>Total Logged</Text>
                 <Text style={{ fontWeight: 600 }}>
-                  {formatMinutes(accumulated.focused + accumulated.admin)} 
+                  {formatMinutes(accumulated.focused + accumulated.admin)}
                   {meetingMinutes > 0 && ` (+ ${formatMinutes(meetingMinutes)} meetings)`}
                 </Text>
               </Space>

--- a/src/renderer/components/work-logger/SwimLaneTimeline.tsx
+++ b/src/renderer/components/work-logger/SwimLaneTimeline.tsx
@@ -84,7 +84,7 @@ export function SwimLaneTimeline({
     const interval = setInterval(() => {
       setCurrentTime(new Date())
     }, 60000) // Update every minute
-    
+
     return () => clearInterval(interval)
   }, [])
 

--- a/src/renderer/components/work-logger/SwimLaneTimeline.tsx
+++ b/src/renderer/components/work-logger/SwimLaneTimeline.tsx
@@ -73,10 +73,20 @@ export function SwimLaneTimeline({
   const [internalExpandedWorkflows, setInternalExpandedWorkflows] = useState<Set<string>>(new Set())
   const [laneHeight, setLaneHeight] = useState(30)
   const [hourWidth, setHourWidth] = useState(80)
+  const [currentTime, setCurrentTime] = useState(new Date())
 
   // Use external state if provided, otherwise use internal
   const expandedWorkflows = externalExpandedWorkflows ?? internalExpandedWorkflows
   const setExpandedWorkflows = onExpandedWorkflowsChange ?? setInternalExpandedWorkflows
+
+  // Update current time every minute
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCurrentTime(new Date())
+    }, 60000) // Update every minute
+    
+    return () => clearInterval(interval)
+  }, [])
 
   // Convert minutes to pixels
   const minutesToPixels = (minutes: number): number => {
@@ -619,6 +629,42 @@ if (!checkOverlap(newSession, laneSessions)) {
                   }}
                 />
               ))}
+
+              {/* Now marker - only show if current time is within the timeline range */}
+              {(() => {
+                const nowHours = currentTime.getHours() + currentTime.getMinutes() / 60
+                if (nowHours >= START_HOUR && nowHours <= END_HOUR) {
+                  const nowMinutes = currentTime.getHours() * 60 + currentTime.getMinutes()
+                  const nowLeft = minutesToPixels(nowMinutes) - TIME_LABEL_WIDTH
+                  return (
+                    <div
+                      style={{
+                        position: 'absolute',
+                        left: nowLeft,
+                        top: 0,
+                        bottom: 0,
+                        width: 2,
+                        backgroundColor: '#ff4d4f',
+                        zIndex: 15,
+                        pointerEvents: 'none',
+                      }}
+                    >
+                      <div
+                        style={{
+                          position: 'absolute',
+                          top: -8,
+                          left: -4,
+                          width: 10,
+                          height: 10,
+                          borderRadius: '50%',
+                          backgroundColor: '#ff4d4f',
+                        }}
+                      />
+                    </div>
+                  )
+                }
+                return null
+              })()}
 
               {/* Sessions */}
               {lane.sessions.map((session, sessionIndex) => {

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -56,7 +56,14 @@
 }
 
 /* Electron window styling */
+/* Allow text selection for better testing and copying */
 body {
+  user-select: text;
+  -webkit-user-select: text;
+}
+
+/* Keep buttons and controls non-selectable for better UX */
+button, .arco-btn, .arco-menu-item {
   user-select: none;
   -webkit-user-select: none;
 }


### PR DESCRIPTION
## Summary
- Add checkbox to hide completed tasks in WorkLoggerDual timeline view
- Display total meeting time in GanttChart summary section  
- Make text selectable throughout app for easier copying during testing

## Changes
1. **Hide Completed Tasks Filter**:
   - Added checkbox control in Timeline View header
   - Filters both regular tasks and workflows based on completion status
   - Applied to both SwimLaneTimeline and CircularClock views
   - Completed tasks shown with striped pattern when visible

2. **Meeting Time Display**:
   - Calculate total meeting time in GanttChart
   - Display in summary section with formatted hours/minutes

3. **Text Selection**:
   - Updated CSS to allow text selection for easier copying during testing
   - Kept buttons/controls non-selectable for better UX

## Test Plan
- [ ] Open WorkLoggerDual and verify hide completed checkbox works
- [ ] Verify completed tasks show with striped pattern when visible
- [ ] Check that meeting time displays correctly in GanttChart summary
- [ ] Test text selection throughout the app

Addresses feedback items from user testing session.

🤖 Generated with [Claude Code](https://claude.ai/code)