### PR TITLE
feat: Enhance amendment applicator to cover 80% of operations

### DIFF
--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -73,33 +73,26 @@
 - **Sleep blocks cut off at midnight in UI**: Fixed type checking for proper rendering
 - **Added comprehensive logging**: Better visibility into schedule generation
 
-## 🔴 CRITICAL Issues (2025-08-29)
+## ✅ Recently Fixed - Amendment Applicator Coverage (2025-08-30)
 
-### 1. Amendment Applicator Limited to 40% Coverage - CRITICAL
-**Severity**: 🔴 CRITICAL  
-**Impact**: Voice amendments fail for most common operations
+### 1. Amendment Applicator Now ~80% Coverage - FIXED
+**Status**: ✅ Fixed (2025-08-30)
+**Previous Impact**: Voice amendments failed for most common operations
 
-**Analysis Completed (2025-08-30):**
-- Only ~40% of task/workflow attributes can be modified via voice
-- Critical missing: deadline management (user's "bedtime to 11pm" failed)
-- See /docs/amendment-applicator-analysis.md for full analysis
+**Implemented Features:**
+- ✅ **DeadlineChange** - Set/change deadlines with hard/soft types
+- ✅ **PriorityChange** - Update importance/urgency/cognitive complexity  
+- ✅ **TypeChange** - Switch between focused/admin/personal task types
+- ✅ **StepRemoval** - Remove workflow steps with dependency cleanup
+- ✅ **AI Parser Updated** - Recognizes all new amendment types
 
-**Missing Critical Features:**
-- **No deadline management** - Cannot set/change deadlines or deadline types
-- **No priority updates** - Cannot change importance/urgency after creation  
-- **No cognitive complexity** - Cannot set mental load ratings (1-5)
-- **No task type changes** - Cannot switch between focused/admin/personal
-- **Step removal not implemented** - Type exists but logic missing
-- **Incomplete step operations** - Duration, notes, time logging TODO
+**Remaining Gaps (Minor):**
+- Step-level duration changes (partial support)
+- Step-level notes (partial support)
+- Step-level time logging (partial support)
+- Step-level priority attributes (schema limitation)
 
-**Required Amendment Types to Implement:**
-1. DeadlineChange - For setting/changing deadlines
-2. PriorityChange - For importance/urgency/complexity
-3. TypeChange - For task/step type modifications
-4. Complete StepRemoval implementation
-5. Step-level duration/notes/time logging
-
-**Priority**: HIGHEST - Users cannot use voice for basic edits
+**Coverage Increased**: From ~40% to ~80% of common operations
 
 ## Known Issues (Updated 2025-08-29)
 

--- a/context/state.md
+++ b/context/state.md
@@ -2,7 +2,27 @@
 
 ## Latest Status (2025-08-30)
 
-### 🚀 Current Session: Comprehensive Scheduling System Fixes
+### 🚀 Recent Accomplishments (PR #38 - Merged)
+
+#### Time Provider System for Development Testing
+1. **Global Time Control** ✅
+   - Created TimeProvider singleton for consistent time across app
+   - LocalStorage persistence for dev time overrides
+   - Event system integration for UI updates
+   - Console commands: setTime(), advanceTime(), clearTime()
+
+2. **Scheduler Async Wait Optimization** ✅  
+   - Prevents unnecessary workflow splitting across days
+   - Keeps bedtime routines together when async wait completes same day
+   - Fixed: 80-minute bedtime routine no longer splits Friday PM/Monday AM
+
+3. **Test Coverage Improvements** ✅
+   - Added 19 comprehensive TimeProvider tests
+   - Created async-wait-scheduling tests
+   - Excluded scripts/ directory from coverage metrics
+   - All tests passing with 0 TypeScript/ESLint errors
+
+### 🚀 Previous Session: Comprehensive Scheduling System Fixes
 
 #### Critical Scheduling Bugs Fixed (Branch: feature/universal-task-quick-edit)
 1. **Sleep blocks deleted during schedule generation** ✅
@@ -95,12 +115,11 @@
 
 ### 🟢 Current Code Status
 - **TypeScript Errors**: 0 ✅
-- **ESLint Errors**: 0 ✅ (warnings only)
+- **ESLint Errors**: 0 ✅ (warnings only in scripts/)
 - **Test Status**: All passing ✅
 - **Build**: Successful ✅
-- **PR #35**: MERGED to main ✅
-- **PR #36**: Ready to merge on feature/universal-task-quick-edit
-- **Current Branch**: feature/universal-task-quick-edit
+- **PR #38**: MERGED to main ✅ (Time Provider & Scheduler Fixes)
+- **Current Branch**: main
 
 ### 🎯 Active Work: Amendment Applicator Enhancement
 Analyzing and documenting gaps in voice amendment capabilities.
@@ -169,4 +188,4 @@ Analyzing and documenting gaps in voice amendment capabilities.
 - Multiple test files updated for new architecture
 
 ---
-*Last Updated: 2025-08-29 3:00 PM PST*
+*Last Updated: 2025-08-30 (Post PR #38 merge)*

--- a/src/renderer/components/voice/VoiceAmendmentModal.tsx
+++ b/src/renderer/components/voice/VoiceAmendmentModal.tsx
@@ -533,7 +533,7 @@ export function VoiceAmendmentModal({
       }
       case 'deadline_change':
       case AmendmentType.DeadlineChange: {
-        const deadlineChange = amendment as any
+        const deadlineChange = amendment as DeadlineChange
         return (
           <Space>
             <Text>Set deadline for</Text>
@@ -553,12 +553,12 @@ export function VoiceAmendmentModal({
       }
       case 'priority_change':
       case AmendmentType.PriorityChange: {
-        const priorityChange = amendment as any
+        const priorityChange = amendment as PriorityChange
         const changes: string[] = []
         if (priorityChange.importance !== undefined) changes.push(`Importance: ${priorityChange.importance}`)
         if (priorityChange.urgency !== undefined) changes.push(`Urgency: ${priorityChange.urgency}`)
         if (priorityChange.cognitiveComplexity !== undefined) changes.push(`Complexity: ${priorityChange.cognitiveComplexity}`)
-        
+
         return (
           <Space>
             <Text>Update priority for</Text>
@@ -574,7 +574,7 @@ export function VoiceAmendmentModal({
       }
       case 'type_change':
       case AmendmentType.TypeChange: {
-        const typeChange = amendment as any
+        const typeChange = amendment as TypeChange
         return (
           <Space>
             <Text>Change type of</Text>
@@ -591,7 +591,7 @@ export function VoiceAmendmentModal({
       }
       case 'step_removal':
       case AmendmentType.StepRemoval: {
-        const stepRemoval = amendment as any
+        const stepRemoval = amendment as StepRemoval
         return (
           <Space>
             <Text>Remove step</Text>

--- a/src/renderer/components/voice/VoiceAmendmentModal.tsx
+++ b/src/renderer/components/voice/VoiceAmendmentModal.tsx
@@ -33,7 +33,7 @@ const normalizeAmendmentType = (type: string | AmendmentType): AmendmentType => 
   if (Object.values(AmendmentType).includes(type as AmendmentType)) {
     return type as AmendmentType
   }
-  
+
   // Map string literals to enum values
   const typeMap: Record<string, AmendmentType> = {
     'status_update': AmendmentType.StatusUpdate,
@@ -49,7 +49,7 @@ const normalizeAmendmentType = (type: string | AmendmentType): AmendmentType => 
     'priority_change': AmendmentType.PriorityChange,
     'type_change': AmendmentType.TypeChange,
   }
-  
+
   return typeMap[type] || (type as AmendmentType)
 }
 
@@ -362,7 +362,7 @@ export function VoiceAmendmentModal({
   const renderAmendmentIcon = (type: Amendment['type']) => {
     // Normalize to enum value for consistent handling
     const enumType = normalizeAmendmentType(type)
-    
+
     switch (enumType) {
       case AmendmentType.StatusUpdate:
         return <IconCheck />
@@ -395,7 +395,7 @@ export function VoiceAmendmentModal({
   const renderAmendmentDescription = (amendment: Amendment, allAmendments?: Amendment[]) => {
     // Normalize to enum value for consistent handling
     const enumType = normalizeAmendmentType(amendment.type)
-    
+
     switch (enumType) {
       case AmendmentType.StatusUpdate: {
         const statusUpdate = amendment as StatusUpdate
@@ -636,7 +636,7 @@ export function VoiceAmendmentModal({
   const getAmendmentTitle = (amendment: Amendment) => {
     // Normalize to enum value for consistent handling
     const enumType = normalizeAmendmentType(amendment.type)
-    
+
     switch (enumType) {
       case AmendmentType.StatusUpdate:
         return 'Status Update'

--- a/src/renderer/components/voice/VoiceAmendmentModal.tsx
+++ b/src/renderer/components/voice/VoiceAmendmentModal.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from 'react'
 import { Modal, Button, Typography, Alert, Space, Card, Tag, Spin, List, Badge, Input, Upload, Slider, InputNumber, Select } from '@arco-design/web-react'
-import { IconSoundFill, IconStop, IconRefresh, IconCheck, IconClose, IconEdit, IconClockCircle, IconFile, IconSchedule, IconMessage, IconPlus, IconLink, IconUpload, IconInfoCircle } from '@arco-design/web-react/icon'
+import { IconSoundFill, IconStop, IconRefresh, IconCheck, IconClose, IconEdit, IconClockCircle, IconFile, IconSchedule, IconMessage, IconPlus, IconLink, IconUpload, IconInfoCircle, IconExclamationCircle, IconMinus } from '@arco-design/web-react/icon'
 import { getDatabase } from '../../services/database'
 import {
   Amendment,
@@ -12,8 +12,12 @@ import {
   NoteAddition,
   DurationChange,
   StepAddition,
+  StepRemoval,
   TaskCreation,
   DependencyChange,
+  DeadlineChange,
+  PriorityChange,
+  TypeChange,
   TaskType,
 } from '../../../shared/amendment-types'
 import { useTaskStore } from '../../store/useTaskStore'
@@ -353,6 +357,18 @@ export function VoiceAmendmentModal({
       case 'dependency_change':
       case AmendmentType.DependencyChange:
         return <IconLink />
+      case 'deadline_change':
+      case AmendmentType.DeadlineChange:
+        return <IconClockCircle />
+      case 'priority_change':
+      case AmendmentType.PriorityChange:
+        return <IconExclamationCircle />
+      case 'type_change':
+      case AmendmentType.TypeChange:
+        return <IconRefresh />
+      case 'step_removal':
+      case AmendmentType.StepRemoval:
+        return <IconMinus />
       default:
         logger.ui.warn('[VoiceAmendmentModal] Unknown amendment type in icon:', type)
         return <IconEdit />
@@ -511,6 +527,79 @@ export function VoiceAmendmentModal({
             )}
             {depChange.stepName && (
               <Text type="secondary">Step: {depChange.stepName}</Text>
+            )}
+          </Space>
+        )
+      }
+      case 'deadline_change':
+      case AmendmentType.DeadlineChange: {
+        const deadlineChange = amendment as any
+        return (
+          <Space>
+            <Text>Set deadline for</Text>
+            <Text bold>{deadlineChange.target.name}</Text>
+            <Text>to</Text>
+            <Text bold>{new Date(deadlineChange.newDeadline).toLocaleDateString()}</Text>
+            {deadlineChange.deadlineType && (
+              <Tag color={deadlineChange.deadlineType === 'hard' ? 'red' : 'orange'}>
+                {deadlineChange.deadlineType}
+              </Tag>
+            )}
+            {deadlineChange.stepName && (
+              <Text type="secondary">Step: {deadlineChange.stepName}</Text>
+            )}
+          </Space>
+        )
+      }
+      case 'priority_change':
+      case AmendmentType.PriorityChange: {
+        const priorityChange = amendment as any
+        const changes: string[] = []
+        if (priorityChange.importance !== undefined) changes.push(`Importance: ${priorityChange.importance}`)
+        if (priorityChange.urgency !== undefined) changes.push(`Urgency: ${priorityChange.urgency}`)
+        if (priorityChange.cognitiveComplexity !== undefined) changes.push(`Complexity: ${priorityChange.cognitiveComplexity}`)
+        
+        return (
+          <Space>
+            <Text>Update priority for</Text>
+            <Text bold>{priorityChange.target.name}</Text>
+            {changes.length > 0 && (
+              <Text>({changes.join(', ')})</Text>
+            )}
+            {priorityChange.stepName && (
+              <Text type="secondary">Step: {priorityChange.stepName}</Text>
+            )}
+          </Space>
+        )
+      }
+      case 'type_change':
+      case AmendmentType.TypeChange: {
+        const typeChange = amendment as any
+        return (
+          <Space>
+            <Text>Change type of</Text>
+            <Text bold>{typeChange.target.name}</Text>
+            <Text>to</Text>
+            <Tag color={typeChange.newType === 'focused' ? 'purple' : typeChange.newType === 'admin' ? 'blue' : 'green'}>
+              {typeChange.newType}
+            </Tag>
+            {typeChange.stepName && (
+              <Text type="secondary">Step: {typeChange.stepName}</Text>
+            )}
+          </Space>
+        )
+      }
+      case 'step_removal':
+      case AmendmentType.StepRemoval: {
+        const stepRemoval = amendment as any
+        return (
+          <Space>
+            <Text>Remove step</Text>
+            <Text bold>{stepRemoval.stepName}</Text>
+            <Text>from</Text>
+            <Text bold>{stepRemoval.workflowTarget.name}</Text>
+            {stepRemoval.reason && (
+              <Text type="secondary">Reason: {stepRemoval.reason}</Text>
             )}
           </Space>
         )

--- a/src/renderer/utils/amendment-applicator.ts
+++ b/src/renderer/utils/amendment-applicator.ts
@@ -560,13 +560,30 @@ export async function applyAmendments(amendments: Amendment[]): Promise<void> {
                   )
 
                   if (stepIndex !== -1) {
-                    // Update step properties (note: step schema may not support all these)
-                    // const updatedSteps = [...workflow.steps]
-                    // TODO: When schema supports step-level priority, implement update here
-                    // Steps don't have importance/urgency in current schema
-                    logger.ui.warn('Step-level priority changes not fully supported in current schema')
-                    Message.warning('Step priority changes are limited in current version')
-                    errorCount++
+                    // Update step properties - schema supports importance and urgency for steps
+                    const updatedSteps = [...workflow.steps]
+                    const step = updatedSteps[stepIndex]
+                    
+                    // Apply the priority changes that are supported
+                    if (change.importance !== undefined) {
+                      step.importance = change.importance
+                    }
+                    if (change.urgency !== undefined) {
+                      step.urgency = change.urgency
+                    }
+                    if (change.cognitiveComplexity !== undefined) {
+                      step.cognitiveComplexity = change.cognitiveComplexity
+                    }
+                    
+                    await db.updateSequencedTask(change.target.id, { steps: updatedSteps })
+                    successCount++
+                    logger.ui.info('Updated step priority:', { 
+                      step: change.stepName,
+                      importance: change.importance,
+                      urgency: change.urgency,
+                      cognitiveComplexity: change.cognitiveComplexity
+                    })
+                    Message.success(`Updated priority for step "${change.stepName}"`)
                   } else {
                     Message.warning(`Step "${change.stepName}" not found`)
                     errorCount++

--- a/src/renderer/utils/amendment-applicator.ts
+++ b/src/renderer/utils/amendment-applicator.ts
@@ -563,7 +563,7 @@ export async function applyAmendments(amendments: Amendment[]): Promise<void> {
                     // Update step properties - schema supports importance and urgency for steps
                     const updatedSteps = [...workflow.steps]
                     const step = updatedSteps[stepIndex]
-                    
+
                     // Apply the priority changes that are supported
                     if (change.importance !== undefined) {
                       step.importance = change.importance
@@ -574,14 +574,14 @@ export async function applyAmendments(amendments: Amendment[]): Promise<void> {
                     if (change.cognitiveComplexity !== undefined) {
                       step.cognitiveComplexity = change.cognitiveComplexity
                     }
-                    
+
                     await db.updateSequencedTask(change.target.id, { steps: updatedSteps })
                     successCount++
-                    logger.ui.info('Updated step priority:', { 
+                    logger.ui.info('Updated step priority:', {
                       step: change.stepName,
                       importance: change.importance,
                       urgency: change.urgency,
-                      cognitiveComplexity: change.cognitiveComplexity
+                      cognitiveComplexity: change.cognitiveComplexity,
                     })
                     Message.success(`Updated priority for step "${change.stepName}"`)
                   } else {

--- a/src/renderer/utils/amendment-applicator.ts
+++ b/src/renderer/utils/amendment-applicator.ts
@@ -561,7 +561,8 @@ export async function applyAmendments(amendments: Amendment[]): Promise<void> {
 
                   if (stepIndex !== -1) {
                     // Update step properties (note: step schema may not support all these)
-                    const updatedSteps = [...workflow.steps]
+                    // const updatedSteps = [...workflow.steps]
+                    // TODO: When schema supports step-level priority, implement update here
                     // Steps don't have importance/urgency in current schema
                     logger.ui.warn('Step-level priority changes not fully supported in current schema')
                     Message.warning('Step priority changes are limited in current version')

--- a/src/shared/amendment-types.ts
+++ b/src/shared/amendment-types.ts
@@ -2,10 +2,10 @@
  * Types for voice amendments and logging
  */
 
-import { AmendmentType, EntityType, TaskStatus, TaskType } from './enums'
+import { AmendmentType, EntityType, TaskStatus, TaskType, DeadlineType } from './enums'
 
 // Re-export enums for convenience
-export { AmendmentType, EntityType, TaskStatus, TaskType }
+export { AmendmentType, EntityType, TaskStatus, TaskType, DeadlineType }
 
 export type AmendmentStatus = 'pending' | 'applied' | 'rejected' | 'error'
 
@@ -109,6 +109,30 @@ export interface WorkflowCreation {
   urgency?: number
 }
 
+export interface DeadlineChange {
+  type: AmendmentType.DeadlineChange
+  target: AmendmentTarget
+  newDeadline: Date
+  deadlineType?: DeadlineType
+  stepName?: string  // For changing step deadline if applicable
+}
+
+export interface PriorityChange {
+  type: AmendmentType.PriorityChange
+  target: AmendmentTarget
+  importance?: number  // 1-10
+  urgency?: number  // 1-10
+  cognitiveComplexity?: 1 | 2 | 3 | 4 | 5
+  stepName?: string  // For changing step priority if applicable
+}
+
+export interface TypeChange {
+  type: AmendmentType.TypeChange
+  target: AmendmentTarget
+  newType: TaskType
+  stepName?: string  // For changing step type
+}
+
 export type Amendment =
   | StatusUpdate
   | TimeLog
@@ -119,6 +143,9 @@ export type Amendment =
   | DependencyChange
   | TaskCreation
   | WorkflowCreation
+  | DeadlineChange
+  | PriorityChange
+  | TypeChange
 
 export interface AmendmentResult {
   amendments: Amendment[]

--- a/src/shared/enums.ts
+++ b/src/shared/enums.ts
@@ -35,6 +35,9 @@ export enum AmendmentType {
   DependencyChange = 'dependency_change',
   TaskCreation = 'task_creation',
   WorkflowCreation = 'workflow_creation',
+  DeadlineChange = 'deadline_change',
+  PriorityChange = 'priority_change',
+  TypeChange = 'type_change',
 }
 
 // Entity types for amendments
@@ -42,6 +45,12 @@ export enum EntityType {
   Task = 'task',
   Workflow = 'workflow',
   Step = 'step',
+}
+
+// Deadline types
+export enum DeadlineType {
+  Hard = 'hard',
+  Soft = 'soft',
 }
 
 // Work session types


### PR DESCRIPTION
## Summary
- Implemented DeadlineChange, PriorityChange, TypeChange, and StepRemoval amendment types
- Increased voice amendment coverage from ~40% to ~80% of common operations
- Updated AI parser prompt to recognize and handle new amendment types

## Changes
### New Amendment Types
1. **DeadlineChange**: Set/update task and workflow deadlines with hard/soft types
2. **PriorityChange**: Modify importance, urgency, and cognitive complexity
3. **TypeChange**: Change task type between focused/admin/personal
4. **StepRemoval**: Remove workflow steps with proper dependency cleanup

### Implementation Details
- Added new enums and interfaces in `amendment-types.ts`
- Implemented handlers in `amendment-applicator.ts` with proper logging
- Updated AI parser prompt with examples and patterns for new types
- Post-processing to convert date strings from Claude to Date objects

## Testing
- All existing tests pass (398 passing, 46 skipped)
- TypeScript: 0 errors
- ESLint: 0 errors (warnings only in scripts/)
- Build successful

## Impact
Users can now use voice commands for:
- "Set deadline to Friday at 5pm" 
- "Make this high priority"
- "This is mentally demanding work" (cognitive complexity)
- "Change to personal task"
- "Remove the review step"

Addresses the critical issue where voice amendments couldn't handle basic operations like deadline changes (user's "bedtime to 11pm" example).

🤖 Generated with Claude Code (https://claude.ai/code)