### PR TITLE
fix: Ensure unique timestamps for feedback items

### DIFF
--- a/context/feedback.json
+++ b/context/feedback.json
@@ -1149,7 +1149,7 @@
     "title": "ESLint Configuration Too Permissive",
     "description": "Current ESLint config doesn't catch potentially undefined values. No strict null checking rules enabled. TypeScript @typescript-eslint/recommended preset too lenient. This leads to bugs like sortedItems[0] access without safety checks. Need to enable strict-boolean-expressions and no-unsafe-member-access, then fix all resulting errors (likely 100+ locations).",
     "source": "TECH_DEBT.md",
-    "timestamp": "2025-09-04T10:50:00.322Z",
+    "timestamp": "2025-09-04T10:50:00.422Z",
     "sessionId": "tech-debt-migration-2025-09-04"
   },
   {
@@ -1163,7 +1163,7 @@
     "title": "Workflow/Task Model Confusion",
     "description": "Workflows stored as Tasks with hasSteps=true causing type confusion throughout codebase. Priority calculation creates fake Task objects from TaskSteps. Duplicate logic for handling tasks vs workflow steps. Constant type casting required. See context/architecture-improvements.md for proposed fix.",
     "source": "TECH_DEBT.md",
-    "timestamp": "2025-09-04T10:50:00.322Z",
+    "timestamp": "2025-09-04T10:50:00.522Z",
     "sessionId": "tech-debt-migration-2025-09-04"
   },
   {
@@ -1175,7 +1175,7 @@
     "title": "LogViewer Database Integration Missing",
     "description": "Cannot view historical logs from previous sessions. IPC handler for get-session-logs not implemented. Database query methods for ErrorLog table needed. Session selector UI disabled but ready. This blocks debugging of past issues. Need to add database methods to fetch ErrorLog entries by session and implement IPC handler in main process.",
     "source": "TECH_DEBT.md",
-    "timestamp": "2025-09-04T10:50:00.322Z",
+    "timestamp": "2025-09-04T10:50:00.622Z",
     "sessionId": "tech-debt-migration-2025-09-04"
   },
   {
@@ -1188,7 +1188,7 @@
     "title": "Scheduling Test Suite Rewrite Needed",
     "description": "Tests written for old deadline-scheduler don't match new SchedulingEngine behavior. Entire deadline-scheduling.test.ts suite skipped. One test in dependency-scheduling.test.ts skipped. Need to write new test suite for unified SchedulingEngine testing deadline pressure, async urgency, and priority calculations in context.",
     "source": "TECH_DEBT.md",
-    "timestamp": "2025-09-04T10:50:00.322Z",
+    "timestamp": "2025-09-04T10:50:00.722Z",
     "sessionId": "tech-debt-migration-2025-09-04"
   },
   {
@@ -1201,7 +1201,7 @@
     "title": "AI Amendment Dependency Editing Not Working",
     "description": "Dependency changes via voice commands fail. Issue discovered during beta test. Need to debug amendment-applicator.ts dependency logic. Voice amendments for dependencies not functional.",
     "source": "TECH_DEBT.md",
-    "timestamp": "2025-09-04T10:50:00.322Z",
+    "timestamp": "2025-09-04T10:50:00.822Z",
     "sessionId": "tech-debt-migration-2025-09-04"
   },
   {
@@ -1213,7 +1213,7 @@
     "title": "Script Directory Organization Issues",
     "description": "1386+ ESLint warnings from scripts using console.log extensively. Consider unified CLI tool instead of 30+ individual scripts. Missing TypeScript types in some scripts. Duplicate functionality across scripts. Need to create unified CLI with subcommands and add proper .eslintrc for scripts directory.",
     "source": "TECH_DEBT.md",
-    "timestamp": "2025-09-04T10:50:00.322Z",
+    "timestamp": "2025-09-04T10:50:00.922Z",
     "sessionId": "tech-debt-migration-2025-09-04"
   },
   {
@@ -1225,7 +1225,7 @@
     "title": "Console Logging Cleanup Needed",
     "description": "Excessive logging in database operations (DB: logs everywhere), amendment parsing flow, and voice modal debugging. Noisy console output affecting development. Need to add debug flag or remove before production.",
     "source": "TECH_DEBT.md",
-    "timestamp": "2025-09-04T10:50:00.322Z",
+    "timestamp": "2025-09-04T10:50:01.022Z",
     "sessionId": "tech-debt-migration-2025-09-04"
   },
   {
@@ -1238,7 +1238,7 @@
     "title": "Test Coverage for Voice Features",
     "description": "Missing tests for voice amendment integration, workflow step addition, IPC enum serialization, and job context integration. Reduced confidence in voice features. Need comprehensive test suite for new functionality.",
     "source": "TECH_DEBT.md",
-    "timestamp": "2025-09-04T10:50:00.322Z",
+    "timestamp": "2025-09-04T10:50:01.122Z",
     "sessionId": "tech-debt-migration-2025-09-04"
   },
   {
@@ -1251,7 +1251,7 @@
     "title": "Workflow UI Polish Needed",
     "description": "Graph view could be more interactive. Step completion UI needs better feedback. Dependency visualization could be clearer. Overall UX improvements needed for workflow management.",
     "source": "TECH_DEBT.md",
-    "timestamp": "2025-09-04T10:50:00.322Z",
+    "timestamp": "2025-09-04T10:50:01.222Z",
     "sessionId": "tech-debt-migration-2025-09-04"
   },
   {
@@ -1263,7 +1263,7 @@
     "title": "Documentation Updates Needed",
     "description": "Architecture diagram still shows old dual model. API documentation for new voice features missing. Testing guide for voice amendments needed. Various documentation files need updates to reflect current state.",
     "source": "TECH_DEBT.md",
-    "timestamp": "2025-09-04T10:50:00.322Z",
+    "timestamp": "2025-09-04T10:50:01.322Z",
     "sessionId": "tech-debt-migration-2025-09-04"
   },
   {
@@ -1275,7 +1275,7 @@
     "title": "Performance Optimizations Needed",
     "description": "Database queries could be optimized. UI re-renders on amendment application. Voice recording file cleanup needed. Performance issues with large workflow handling.",
     "source": "TECH_DEBT.md",
-    "timestamp": "2025-09-04T10:50:00.322Z",
+    "timestamp": "2025-09-04T10:50:01.422Z",
     "sessionId": "tech-debt-migration-2025-09-04"
   }
 ]

--- a/scripts/analysis/fix-feedback-timestamps.js
+++ b/scripts/analysis/fix-feedback-timestamps.js
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+
+/**
+ * Script to fix duplicate timestamps in feedback.json
+ * Ensures each item has a unique timestamp for proper UI selection
+ */
+
+const fs = require('fs')
+const path = require('path')
+
+const FEEDBACK_FILE = path.join(__dirname, '..', '..', 'context', 'feedback.json')
+
+function loadFeedback() {
+  try {
+    const data = fs.readFileSync(FEEDBACK_FILE, 'utf8')
+    return JSON.parse(data)
+  } catch (error) {
+    console.error('Error loading feedback.json:', error.message)
+    process.exit(1)
+  }
+}
+
+function saveFeedback(feedback) {
+  try {
+    const data = JSON.stringify(feedback, null, 2)
+    fs.writeFileSync(FEEDBACK_FILE, data, 'utf8')
+    console.log(`✅ Saved ${feedback.length} items to feedback.json`)
+  } catch (error) {
+    console.error('Error saving feedback.json:', error.message)
+    process.exit(1)
+  }
+}
+
+function main() {
+  console.log('🔧 Fixing duplicate timestamps in feedback.json...')
+  const feedback = loadFeedback()
+  console.log(`  Found ${feedback.length} total items`)
+
+  // Group items by sessionId + timestamp to find duplicates
+  const groups = new Map()
+  feedback.forEach((item, index) => {
+    const key = `${item.sessionId}-${item.timestamp}`
+    if (!groups.has(key)) {
+      groups.set(key, [])
+    }
+    groups.get(key).push({ item, index })
+  })
+
+  // Find groups with duplicates
+  let fixedCount = 0
+  groups.forEach((group, key) => {
+    if (group.length > 1) {
+      console.log(`  Found ${group.length} items with duplicate key: ${key}`)
+
+      // Fix timestamps by adding milliseconds
+      const baseTime = new Date(group[0].item.timestamp).getTime()
+      group.forEach(({ index }, groupIndex) => {
+        if (groupIndex > 0) {
+          // Add 100ms for each duplicate to ensure uniqueness
+          const newTimestamp = new Date(baseTime + (groupIndex * 100))
+          feedback[index].timestamp = newTimestamp.toISOString()
+          fixedCount++
+        }
+      })
+    }
+  })
+
+  if (fixedCount > 0) {
+    console.log(`\n📝 Fixed ${fixedCount} duplicate timestamps`)
+    saveFeedback(feedback)
+    console.log('✨ All feedback items now have unique timestamps!')
+  } else {
+    console.log('✨ No duplicate timestamps found - feedback.json is already correct!')
+  }
+
+  // Verify uniqueness
+  const uniqueKeys = new Set()
+  let duplicatesRemain = false
+  feedback.forEach(item => {
+    const key = `${item.sessionId}-${item.timestamp}`
+    if (uniqueKeys.has(key)) {
+      console.error(`❌ ERROR: Duplicate key still exists: ${key}`)
+      duplicatesRemain = true
+    }
+    uniqueKeys.add(key)
+  })
+
+  if (!duplicatesRemain) {
+    console.log('✅ Verification passed: All items have unique IDs')
+  } else {
+    console.error('❌ Verification failed: Duplicates still exist!')
+    process.exit(1)
+  }
+}
+
+main()

--- a/scripts/analysis/migrate-tech-debt.js
+++ b/scripts/analysis/migrate-tech-debt.js
@@ -140,15 +140,17 @@ function main() {
   const existingTitles = new Set(feedback.map(item => item.title))
 
   let addedCount = 0
-  const timestamp = new Date().toISOString()
+  const baseTimestamp = new Date()
 
-  techDebtItems.forEach(item => {
+  techDebtItems.forEach((item, index) => {
     if (existingTitles.has(item.title)) {
       console.log(`  ⏭️  Skipping duplicate: ${item.title}`)
     } else {
+      // Add unique timestamp for each item (increment by 100ms to ensure uniqueness)
+      const itemTimestamp = new Date(baseTimestamp.getTime() + (index * 100))
       feedback.push({
         ...item,
-        timestamp,
+        timestamp: itemTimestamp.toISOString(),
         sessionId: 'tech-debt-migration-2025-09-04',
       })
       addedCount++


### PR DESCRIPTION
## Summary
- Fixed feedback item selection bug where all migrated tech debt items were selected together
- Updated migration script to generate unique timestamps
- Created repair script for existing duplicate timestamps

## Problem
All 12 migrated tech debt items had identical timestamps and sessionIds, resulting in duplicate IDs in the FeedbackViewer component. This caused all items to be selected together when any one was clicked.

## Solution
1. Updated `migrate-tech-debt.js` to increment timestamps by 100ms for each item
2. Created `fix-feedback-timestamps.js` to repair existing duplicates
3. Fixed 11 duplicate timestamps in feedback.json

## Technical Details
The FeedbackViewer uses `${timestamp}-${sessionId}` as the unique key for each item, so unique timestamps are essential for proper UI behavior.

## Test Plan
- [x] Verified each feedback item can be selected independently
- [x] TypeScript: 0 errors
- [x] ESLint: 0 errors (1717 warnings from scripts)
- [x] All 523 tests passing

🤖 Generated with [Claude Code](https://claude.ai/code)